### PR TITLE
fix MD5 calculation of empty message

### DIFF
--- a/msg-utils/md5.go
+++ b/msg-utils/md5.go
@@ -155,7 +155,13 @@ func md5Text(rt reflect.Type, rosTag string) (string, bool, error) {
 
 			ret += text + " " + name + "\n"
 		}
-		return ret[:len(ret)-1], true, nil
+
+		// Remove trailing newline
+		if len(ret) > 0 {
+			ret = ret[:len(ret)-1]
+		}
+
+		return ret, true, nil
 	}
 
 	return "", false, fmt.Errorf("unsupported field type '%s'", rt.String())

--- a/msg-utils/md5_test.go
+++ b/msg-utils/md5_test.go
@@ -122,6 +122,12 @@ var casesMd5Message = []struct {
 		&Log{},
 		"acffd30cd6b6de30f120938c17c593fb",
 	},
+	{
+		"empty struct",
+		&struct {
+		}{},
+		"d41d8cd98f00b204e9800998ecf8427e",
+	},
 }
 
 func TestMd5Message(t *testing.T) {


### PR DESCRIPTION
This allows using messages that refer to move_base_msgs/MoveBaseResult
for example.