### PR TITLE
Check for http:// prefix in MasterAddress.

### DIFF
--- a/node.go
+++ b/node.go
@@ -215,6 +215,9 @@ func NewNode(conf NodeConf) (*Node, error) {
 		conf.MasterAddress = "127.0.0.1:11311"
 	}
 
+	// support ROS-style master address, in order to increase interoperability
+	conf.MasterAddress = strings.TrimPrefix(conf.MasterAddress, "http://")
+
 	// solve master address once
 	masterAddr, err := net.ResolveTCPAddr("tcp", conf.MasterAddress)
 	if err != nil {

--- a/node_test.go
+++ b/node_test.go
@@ -100,7 +100,7 @@ func (c *container) waitOutput() string {
 	return string(out)
 }
 
-func TestNodeOpen(t *testing.T) {
+func TestNodeMasterOpen(t *testing.T) {
 	m, err := newContainerMaster()
 	require.NoError(t, err)
 	defer m.close()
@@ -114,7 +114,21 @@ func TestNodeOpen(t *testing.T) {
 	defer n.Close()
 }
 
-func TestNodeNoMaster(t *testing.T) {
+func TestNodeOpenMasterHttp(t *testing.T) {
+	m, err := newContainerMaster()
+	require.NoError(t, err)
+	defer m.close()
+
+	n, err := NewNode(NodeConf{
+		Namespace:     "/myns",
+		Name:          "goroslib",
+		MasterAddress: "http://" + m.IP() + ":11311",
+	})
+	require.NoError(t, err)
+	defer n.Close()
+}
+
+func TestNodeMasterNo(t *testing.T) {
 	_, err := NewNode(NodeConf{
 		Namespace:     "/myns",
 		Name:          "goroslib",


### PR DESCRIPTION
When the client uses the env. variable ROS_MASTER_URI for the master address definition
in node creation, then a conflict between roscore and the node appears.
The problem is that roscore accepts ROS_MASTER_URI with the prefix http:// in contrast
to the Go net.ResolveTCPAddr method that requires to omit that prefix.
This fix checks conf.MasterAddress for prefix presence and trims it if necessary.
Finally, it will be possible to use the env. variable ROS_MASTER_URI both with goroslib and roscore.

fix #39