### PR TITLE
Support namespace change from the "ROS_NAMESPACE" env var 

### DIFF
--- a/node.go
+++ b/node.go
@@ -46,6 +46,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -209,6 +210,10 @@ type Node struct {
 
 // NewNode allocates a Node. See NodeConf for the options.
 func NewNode(conf NodeConf) (*Node, error) {
+	if os.Getenv("ROS_NAMESPACE") != "" {
+		conf.Namespace = os.Getenv("ROS_NAMESPACE")
+	}
+
 	if conf.Namespace == "" {
 		conf.Namespace = "/"
 	}


### PR DESCRIPTION
Read the `ROS_NAMESPACE` Env. variable and set the `conf.Namespace` if it's set. Allowing namespace remapping of the node from `.launch` files or the Env vars.

@aler9 
(tagging the maintainer seems to be standard practice in other repos;idk if it applies here and apologies if it doesn't.)