### PR TITLE
fix(xmlrpc): workaround for non-standard `utf8` encoding name

### DIFF
--- a/pkg/xmlrpc/request.go
+++ b/pkg/xmlrpc/request.go
@@ -22,6 +22,12 @@ func requestDecodeRaw(r io.Reader) (*RequestRaw, error) {
 	raw := &RequestRaw{
 		dec: xml.NewDecoder(r),
 	}
+	raw.dec.CharsetReader = func(charset string, input io.Reader) (io.Reader, error) {
+		if charset == "utf8" {
+			return input, nil
+		}
+		return nil, fmt.Errorf("unknown charset %q", charset)
+	}
 
 	err := xmlGetProcessingInstruction(raw.dec)
 	if err != nil {

--- a/pkg/xmlrpc/request_test.go
+++ b/pkg/xmlrpc/request_test.go
@@ -61,6 +61,44 @@ var casesRequest = []struct {
 			true,
 		},
 	},
+	{
+		"base with utf8 encoding",
+		[]byte(`<?xml version="1.0" encoding="utf8"?><methodCall><methodName>testMethodName</methodName><params>` +
+			`<param><value><string></string></value></param>` +
+			`<param><value><array><data>` +
+			`<value>test1</value>` +
+			`<value>test2</value>` +
+			`<value><i4>123</i4></value>` +
+			`<value><double>-1.324543</double></value>` +
+			`</data></array></value></param>` +
+			`<param><value><boolean>1</boolean></value></param>` +
+			`</params></methodCall>`),
+		[]byte(`<?xml version="1.0"?><methodCall><methodName>testMethodName</methodName><params>` +
+			`<param><value></value></param>` +
+			`<param><value><array><data>` +
+			`<value>test1</value>` +
+			`<value>test2</value>` +
+			`<value><i4>123</i4></value>` +
+			`<value><double>-1.324543</double></value>` +
+			`</data></array></value></param>` +
+			`<param><value><boolean>1</boolean></value></param>` +
+			`</params></methodCall>`),
+		"testMethodName",
+		struct {
+			Param7 string
+			Param8 Substruct
+			Param9 bool
+		}{
+			"",
+			Substruct{
+				"test1",
+				"test2",
+				123,
+				-1.324543,
+			},
+			true,
+		},
+	},
 }
 
 func TestRequestDecode(t *testing.T) {

--- a/pkg/xmlrpc/response.go
+++ b/pkg/xmlrpc/response.go
@@ -2,12 +2,19 @@ package xmlrpc
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io"
 	"reflect"
 )
 
 func responseDecode(r io.Reader, dest interface{}) error {
 	dec := xml.NewDecoder(r)
+	dec.CharsetReader = func(charset string, input io.Reader) (io.Reader, error) {
+		if charset == "utf8" {
+			return input, nil
+		}
+		return nil, fmt.Errorf("unknown charset %q", charset)
+	}
 
 	err := xmlGetProcessingInstruction(dec)
 	if err != nil {

--- a/pkg/xmlrpc/response_test.go
+++ b/pkg/xmlrpc/response_test.go
@@ -60,6 +60,51 @@ var casesResponse = []struct {
 			"testing",
 		},
 	},
+	{
+		"base with utf8 encoding",
+		[]byte(`<?xml version="1.0" encoding="utf8"?><methodResponse><params>` +
+			`<param><value><array><data>` +
+			`<value><i4>1</i4></value>` +
+			`<value></value>` +
+			`<value><array><data>` +
+			`<value>TCPROS</value>` +
+			`<value>testing</value>` +
+			`<value><i4>123</i4></value>` +
+			`<value><double>-1.324543</double></value>` +
+			`</data></array></value>` +
+			`<value>testing</value>` +
+			`</data></array></value></param>` +
+			`</params></methodResponse>`),
+		[]byte(`<?xml version="1.0"?><methodResponse><params>` +
+			`<param><value><array><data>` +
+			`<value><i4>1</i4></value>` +
+			`<value></value>` +
+			`<value><array><data>` +
+			`<value>TCPROS</value>` +
+			`<value>testing</value>` +
+			`<value><i4>123</i4></value>` +
+			`<value><double>-1.324543</double></value>` +
+			`</data></array></value>` +
+			`<value>testing</value>` +
+			`</data></array></value></param>` +
+			`</params></methodResponse>`),
+		struct {
+			Param1 int
+			Param2 string
+			Param3 Substruct
+			Param4 string
+		}{
+			1,
+			"",
+			Substruct{
+				"TCPROS",
+				"testing",
+				123,
+				-1.324543,
+			},
+			"testing",
+		},
+	},
 }
 
 func TestResponseDecode(t *testing.T) {


### PR DESCRIPTION
## Description

Certain clients include `encoding=utf8` (note the missing `-`) in the xmlrpc message which causes a `400 Bad Request` error to be sent back to the client due to a missing charset reader. 

This fix checks that if we get an "utf8" encoding we just proxy it through (i.e. treat it the same as if it was an `utf-8`). If other charsets are received we error out (same as it would without this fix).

This all comes from the fact that the xml decoder checks for "utf-8" charset, not "utf8".

The offending client where I found this is the [Foxglove Studio](https://github.com/foxglove/studio).

## Checks done
- [x] `make test`
- [x] `make lint`
- [x] tested manually with Foxglove Studio