### PR TITLE
fix: more performant encoding of []byte

### DIFF
--- a/pkg/protocommon/message.go
+++ b/pkg/protocommon/message.go
@@ -400,6 +400,11 @@ func binaryEncodeValue(w *bytes.Buffer, src reflect.Value, dest []byte) {
 		binary.LittleEndian.PutUint32(dest, uint32(nano%1000000000))
 		w.Write(dest[:4])
 
+	case []uint8:
+		binary.LittleEndian.PutUint32(dest, uint32(len(cv)))
+		w.Write(dest[:4])
+		w.Write(cv)
+
 	default:
 		switch src.Elem().Kind() {
 		case reflect.Slice:


### PR DESCRIPTION
instead of looping over each individual value and writing to the byte
buffer, write it as a whole immediately.

For messages containing large buffers (such as a PointCloud2 for example),
this makes a _huge_ difference (factor 100 sometimes on my machine).