### PR TITLE
Allow setting up pub/sub using a reflected type

### DIFF
--- a/pkg/msgproc/definition.go
+++ b/pkg/msgproc/definition.go
@@ -18,6 +18,11 @@ type def struct {
 // Definition returns the definition of a message and of all its parents.
 func Definition(msg interface{}) (string, error) {
 	msgt := reflect.TypeOf(msg)
+	return DefinitionFromReflect(msgt)
+}
+
+// Definition returns the definition of a message and of all its parents from a reflected type.
+func DefinitionFromReflect(msgt reflect.Type) (string, error) {
 	if msgt.Kind() != reflect.Struct {
 		return "", fmt.Errorf("message must be a struct")
 	}

--- a/pkg/msgproc/md5.go
+++ b/pkg/msgproc/md5.go
@@ -8,6 +8,11 @@ import (
 // MD5 returns the checksum of a message.
 func MD5(msg interface{}) (string, error) {
 	msgt := reflect.TypeOf(msg)
+	return MD5FromReflect(msgt)
+}
+
+// MD5FromReflect returns the checksum of a message from a reflected type.
+func MD5FromReflect(msgt reflect.Type) (string, error) {
 	if msgt.Kind() != reflect.Struct {
 		return "", fmt.Errorf("message must be a struct")
 	}

--- a/pkg/msgproc/type.go
+++ b/pkg/msgproc/type.go
@@ -8,8 +8,13 @@ import (
 )
 
 // Type returns the type of a message.
-func Type(msg interface{}) (string, error) {
+func Type(msg interface{}) (string, error) {	
 	msgt := reflect.TypeOf(msg)
+	return TypeFromReflect(msgt)
+}
+
+// TypeFromReflect returns the type of a message based on a reflected type.
+func TypeFromReflect(msgt reflect.Type) (string, error) {
 	if msgt.Kind() != reflect.Struct {
 		return "", fmt.Errorf("message must be a struct")
 	}


### PR DESCRIPTION
Hi @aler9:

In our project, we need to setup pub/sub with a type from a configuration file. So, I extended the project a bit to allow a reflect type (MessageType) to be passed into PublisherConfig/SubscriberConfig. In this way, a user can use a dynamically constructed type (based on a configuration file, for example) instead of passing a message instance. Please let me know how you think. Thanks! 

Regards,
Haishi2016