### PR TITLE
service client: avoid closing conn if it has been reset

### DIFF
--- a/serviceclient.go
+++ b/serviceclient.go
@@ -121,8 +121,9 @@ func (sc *ServiceClient) CallContext(ctx context.Context, req interface{}, res i
 	go func() {
 		select {
 		case <-ctx.Done():
-			sc.conn.Close()
-
+			if sc.conn != nil {
+				sc.conn.Close()
+			}
 		case <-funcDone:
 			return
 		}


### PR DESCRIPTION
When error happens, `CallContext` returns and the caller may cancel the context, which triggers `sc.conn.Close()` on `nil`. This prevents that from happening. I wanted to add test coverage but I couldn't find how to launch the `goroslib-test-master` container to pass the tests.