### PR TITLE
allow using struct with the very same fields as service client req and res

### DIFF
--- a/serviceclient.go
+++ b/serviceclient.go
@@ -239,6 +239,11 @@ func (sc *ServiceClient) createConn(ctx context.Context) error {
 }
 
 func haveSameMD5(a interface{}, b interface{}) bool {
+	// if input types are the same, skip MD5 computation in order to improve performance
+	if reflect.TypeOf(a) == reflect.TypeOf(b) {
+		return true
+	}
+
 	ac, _ := msgproc.MD5(a)
 	bc, _ := msgproc.MD5(b)
 	return ac == bc

--- a/serviceclient.go
+++ b/serviceclient.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aler9/goroslib/pkg/msgproc"
 	"github.com/aler9/goroslib/pkg/protocommon"
 	"github.com/aler9/goroslib/pkg/prototcp"
 	"github.com/aler9/goroslib/pkg/serviceproc"
@@ -105,10 +106,10 @@ func (sc *ServiceClient) Call(req interface{}, res interface{}) error {
 // CallContext sends a request to a service provider and reads a response.
 // It allows to set a context that can be used to terminate the function.
 func (sc *ServiceClient) CallContext(ctx context.Context, req interface{}, res interface{}) error {
-	if reflect.TypeOf(req) != reflect.PtrTo(reflect.TypeOf(sc.srvReq)) {
+	if !haveSameMD5(reflect.ValueOf(req).Elem().Interface(), sc.srvReq) {
 		panic("wrong req")
 	}
-	if reflect.TypeOf(res) != reflect.PtrTo(reflect.TypeOf(sc.srvRes)) {
+	if !haveSameMD5(reflect.ValueOf(res).Elem().Interface(), sc.srvRes) {
 		panic("wrong res")
 	}
 
@@ -235,4 +236,10 @@ func (sc *ServiceClient) createConn(ctx context.Context) error {
 
 	sc.conn = conn
 	return nil
+}
+
+func haveSameMD5(a interface{}, b interface{}) bool {
+	ac, _ := msgproc.MD5(a)
+	bc, _ := msgproc.MD5(b)
+	return ac == bc
 }


### PR DESCRIPTION
This loosens the requirement of having to use the very same structs defined in services.

It's not uncommon to design the services to have the same response format for easier handling on both sides, and occasionally, different services may use the same request format. Here are two real world examples:
```
string control_mode
---
bool   success
string message
```

```
uint8 color
---
bool success
string message
```
Using the same response struct can greatly simplify code, like using the same struct to receive all responses and turn to `error`.

The added tests passed locally.