### PR TITLE
return predefined error when node/provider is terminated

### DIFF
--- a/node.go
+++ b/node.go
@@ -191,6 +191,9 @@ type NodeConf struct {
 	args []string
 }
 
+// ErrNodeTerminated is the error when the node has been terminated.
+var ErrNodeTerminated = fmt.Errorf("node terminated")
+
 // Node is a ROS Node, an entity that can create subscribers, publishers, service providers,
 // service clients, action servers and action clients.
 type Node struct {

--- a/publisher.go
+++ b/publisher.go
@@ -128,7 +128,7 @@ func NewPublisher(conf PublisherConf) (*Publisher, error) {
 		}
 
 	case <-conf.Node.ctx.Done():
-		return nil, fmt.Errorf("terminated")
+		return nil, ErrNodeTerminated
 	}
 
 	go p.run()

--- a/serviceprovider.go
+++ b/serviceprovider.go
@@ -33,6 +33,9 @@ type ServiceProviderConf struct {
 	onClient func()
 }
 
+// ErrProviderTerminated is the error when the service provider has been terminated.
+var ErrProviderTerminated = fmt.Errorf("service provider terminated")
+
 // ServiceProvider is a ROS service provider, an entity that can receive requests
 // and send back responses.
 type ServiceProvider struct {
@@ -150,7 +153,7 @@ func NewServiceProvider(conf ServiceProviderConf) (*ServiceProvider, error) {
 		}
 
 	case <-sp.ctx.Done():
-		return nil, fmt.Errorf("terminated")
+		return nil, ErrProviderTerminated
 	}
 
 	go sp.run()

--- a/serviceproviderclient.go
+++ b/serviceproviderclient.go
@@ -2,7 +2,6 @@ package goroslib
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/aler9/goroslib/pkg/prototcp"
@@ -61,7 +60,7 @@ func (spc *serviceProviderClient) run() {
 					req: req,
 				}:
 				case <-spc.sp.ctx.Done():
-					return fmt.Errorf("terminated")
+					return ErrProviderTerminated
 				}
 			}
 		}()

--- a/subscriber.go
+++ b/subscriber.go
@@ -150,7 +150,7 @@ func NewSubscriber(conf SubscriberConf) (*Subscriber, error) {
 		}
 
 	case <-conf.Node.ctx.Done():
-		return nil, fmt.Errorf("terminated")
+		return nil, ErrNodeTerminated
 	}
 
 	go s.run()


### PR DESCRIPTION
So the caller can do something specific about it, like creating a new node, etc.