### PR TITLE
log when getting shutdown request

### DIFF
--- a/node_api_slave_server.go
+++ b/node_api_slave_server.go
@@ -78,6 +78,7 @@ func (n *Node) handleAPISlaveServer(req apislave.Request) apislave.Response {
 		}
 
 	case *apislave.RequestShutdown:
+		n.Log(LogLevelInfo, "got shutdown request from %s: %s", reqt.CallerID, reqt.Reason)
 		n.ctxCancel()
 
 		return apislave.ResponseShutdown{


### PR DESCRIPTION
Node shutdown has significant impact, and if it's not initiated by the caller, it can be difficult to figure out why without this log.

In my case, it took me several hours to realize that other nodes keep stopping subscribing not because of my code bug - it's because another copy of my code tries to run in background, so ROS master keeps kicking out my node because a new node is joining. I immediately saw the reason with this line in logs.
```
got shutdown request from /master: [/hermes] Reason: new node registered with same name
```